### PR TITLE
docs: refresh CONTRIBUTING; fix app Slint paths; macOS network-service build

### DIFF
--- a/apps/calendar/build.rs
+++ b/apps/calendar/build.rs
@@ -7,7 +7,7 @@ fn main() {
     // Include the shared UI directory so we can import calendar.slint, theme.slint, etc.
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/container-manager/build.rs
+++ b/apps/container-manager/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/document-editor/build.rs
+++ b/apps/document-editor/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/download-manager/build.rs
+++ b/apps/download-manager/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/email/build.rs
+++ b/apps/email/build.rs
@@ -7,7 +7,7 @@ fn main() {
     // Include the shared UI directory so we can import email.slint, theme.slint, etc.
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/image-viewer/build.rs
+++ b/apps/image-viewer/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/music-player/build.rs
+++ b/apps/music-player/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/network-manager/build.rs
+++ b/apps/network-manager/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/notes/build.rs
+++ b/apps/notes/build.rs
@@ -7,7 +7,7 @@ fn main() {
     // Include the shared UI directory so we can import notes_editor.slint, theme.slint, etc.
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/presentation/build.rs
+++ b/apps/presentation/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/snippet-manager/build.rs
+++ b/apps/snippet-manager/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/spreadsheet/build.rs
+++ b/apps/spreadsheet/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/system-monitor/build.rs
+++ b/apps/system-monitor/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/terminal/build.rs
+++ b/apps/terminal/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/text-editor/build.rs
+++ b/apps/text-editor/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+        .join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())

--- a/apps/weather/build.rs
+++ b/apps/weather/build.rs
@@ -4,17 +4,17 @@ fn main() {
     let ui_kit_path = std::env::var("DEP_YANTRIK_UI_KIT_SLINT_PATH")
         .expect("yantrik-ui-kit must be a dependency");
 
-    // Include the shared UI directory so we can import weather.slint, theme.slint, etc.
+    // Shared Slint lives under yantrik-ui-slint/ui (weather.slint, components/, …).
+    // Older layout used crates/yantrik-ui/ui — that path no longer exists.
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let shared_ui_path = std::path::Path::new(&manifest_dir)
-        .join("../../crates/yantrik-ui/ui");
+    let ui_slint_path = std::path::Path::new(&manifest_dir).join("../../crates/yantrik-ui-slint/ui");
 
     let config = slint_build::CompilerConfiguration::new()
         .with_style("fluent-dark".into())
         .with_include_paths(vec![
             design_tokens_path.into(),
             ui_kit_path.into(),
-            shared_ui_path,
+            ui_slint_path,
         ]);
 
     slint_build::compile_with_config("ui/app.slint", config).unwrap();

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -185,5 +185,9 @@ bash deploy/yantrik-os/boot-desktop.sh
 
 ### Known Issues
 
-- **rustc 1.93.1 ICE in `check_mod_deathness`**: Add `#[allow(dead_code)]` to affected module declarations
-- **Local development**: Use workspace `[patch]` sections to override git dependencies with local paths when developing across multiple repos simultaneously.
+- **rustc 1.93.x internal compiler error (ICE) around dead-code / early lints**  
+  This is a **compiler bug**, not bad code in Yantrik. The `yantrik-ui` crate already carries mitigations: see **`crates/yantrik-ui/src/main.rs`** (`#![allow(unused)]` at crate root and `#[allow(dead_code)]` on the `mod` lines called out in comments there).  
+  If you still hit an ICE on **`cargo check`** with another crate, use the stack trace to find the **`mod`** involved and add `#[allow(dead_code)]` on that declaration, or try **`rustup update`** to a newer stable toolchain where the bug may already be fixed.
+
+- **`[patch]` in the root `Cargo.toml`**  
+  The workspace may patch `yantrik-ml` / `yantrikdb-core` to **path dependencies** for in-tree builds. That is intentional for this repo. Only edit `[patch]` when you are deliberately developing those libraries from separate local checkouts alongside `yantrik-os`; otherwise leave it as committed.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,20 +2,39 @@
 
 ## Architecture
 
-Yantrik OS is a single Rust binary that combines three threads:
+The runtime is still organized around **three cooperating roles** (same mental model as the README):
 
 1. **Main thread** — Slint UI (event loop, rendering)
-2. **SystemObserver thread** — D-Bus, inotify, sysinfo polling (battery, WiFi, processes, idle)
-3. **Companion Worker thread** — LLM inference, memory search, tool execution
+2. **SystemObserver** — D-Bus, inotify, sysinfo polling (battery, WiFi, processes, idle)
+3. **Companion worker** — LLM inference, memory search, tool execution
 
-```
-crates/
-  yantrik-os/        # SystemObserver, events, platform abstraction
-  yantrikdb-core/    # Memory DB (SQLite + HNSW vector search, knowledge graph, vault)
-  yantrik-ml/        # LLM backends (Ollama API, OpenAI API, Claude CLI, llama.cpp)
-  yantrik-companion/ # Agent brain: tools, instincts, bond, personality, cortex
-  yantrik-ui/        # Slint desktop shell (all UI, wiring, features)
-```
+The **Cargo workspace** is larger than the classic “five crates” diagram. The authoritative list of packages is **`[workspace].members` in the repo root `Cargo.toml`**.
+
+### Layout (summary)
+
+**Crates (`crates/`):**
+
+| Crate | Role |
+|-------|------|
+| `yantrik` | Main binary / composition |
+| `yantrik-ui` | Desktop shell, Slint, `wire/` callbacks |
+| `yantrik-os` | System observer, platform integration |
+| `yantrik-companion` | Agent loop, wiring to tools and ML |
+| `yantrik-companion-core` | `Tool` trait, `ToolContext`, shared types |
+| `yantrik-companion-tools` | **Tool implementations** (one module per domain) |
+| `yantrik-companion-instincts` | Proactive instincts |
+| `yantrik-companion-cortex` | Cortex / pattern logic |
+| `yantrik-chat` | Chat-side plumbing |
+| `yantrik-ml` | LLM backends (also pulled in via workspace dependencies / path patches) |
+| `yantrikdb-core`, `yantrikdb-server` | Memory DB and server |
+| `yantrik-app-runtime` | App host / runtime |
+| `yantrik-ui-slint`, `yantrik-ui-kit`, `yantrik-shell-core` | UI layers and shell primitives |
+| `yantrik-ipc-contracts`, `yantrik-ipc-transport` | IPC |
+| `yantrik-service-sdk`, `yantrik-manifest`, `yantrik-design-tokens` | Shared infrastructure |
+
+**Apps (`apps/`)** — One package per built-in app (e.g. `spreadsheet`, `email`, `terminal`).
+
+**Services (`services/`)** — Background services (e.g. `email-service`, `calendar-service`).
 
 ### Wire Pattern
 
@@ -27,11 +46,11 @@ pub fn wire(ui: &App, ctx: &AppContext) {
 }
 ```
 
-Registered once in `wire/mod.rs`. This keeps `main.rs` untouched when adding features.
+Registered once in [`crates/yantrik-ui/src/wire/mod.rs`](../crates/yantrik-ui/src/wire/mod.rs). This keeps entrypoints thin when adding features.
 
 ### Tool Pattern
 
-Each tool category lives in `crates/yantrik-companion/src/tools/<name>.rs`:
+Each tool category lives in **`crates/yantrik-companion-tools/src/<name>.rs`**. The crate re-exports the `Tool` trait from `yantrik-companion-core` (see [`lib.rs`](../crates/yantrik-companion-tools/src/lib.rs)).
 
 ```rust
 pub fn register(reg: &mut ToolRegistry) {
@@ -55,11 +74,12 @@ Permission levels: `Safe` (read-only) < `Standard` (reversible writes) < `Sensit
 
 ## Adding a New Tool
 
-1. Create `crates/yantrik-companion/src/tools/mytool.rs`
-2. Implement `Tool` trait for each tool (see `git.rs` for a complete example)
-3. Add `pub mod mytool;` to `tools/mod.rs`
-4. Add `mytool::register(&mut reg);` in `build_registry()`
-5. Run `cargo check -p yantrik-companion`
+1. Create `crates/yantrik-companion-tools/src/mytool.rs`
+2. Implement `Tool` for each tool (see [`git.rs`](../crates/yantrik-companion-tools/src/git.rs) for a full example with `register()`)
+3. Add `pub mod mytool;` to [`lib.rs`](../crates/yantrik-companion-tools/src/lib.rs) and call `mytool::register(reg)` from `register_all()`
+4. Run `cargo check -p yantrik-companion-tools` (and `cargo check -p yantrik-companion` if you change how tools are wired in the main agent)
+
+Some tools need config from the running app (e.g. canvas, vision, github) and are **registered from `yantrik-companion`** instead of inside `register_all()`—follow existing patterns in `lib.rs` comments when adding similar tools.
 
 **Tips:**
 - Shell out to system CLIs when possible (no extra Rust deps)
@@ -145,10 +165,12 @@ Set `enabled: false` or delete the file to revert to the default Firelight theme
 cd /mnt/c/Users/<you>/path/to/yantrik-os
 CARGO_TARGET_DIR=/home/<user>/target-yantrik cargo check
 
-# Check specific crate
+# Check specific workspace members (non-exhaustive)
 cargo check -p yantrik-ui
 cargo check -p yantrik-companion
-cargo check -p yantrik-ml
+cargo check -p yantrik-companion-tools
+cargo check -p yantrik-os
+cargo check -p yantrik
 ```
 
 ### Run in QEMU

--- a/services/network-service/src/main.rs
+++ b/services/network-service/src/main.rs
@@ -306,7 +306,8 @@ mod platform {
         }
 
         let addr = unsafe { ifr.ifr_ifru.ifru_addr };
-        if addr.sa_family != libc::AF_INET as u16 {
+        // `sa_family` is `u8` on macOS/BSD and `u16` on Linux — compare via `u32`.
+        if addr.sa_family as u32 != libc::AF_INET as u32 {
             return None;
         }
 


### PR DESCRIPTION
- Document expanded Cargo workspace (crates, apps/, services/) vs five-crate diagram
- Point tool development at yantrik-companion-tools and register_all()
- Fix wire/mod.rs and git.rs reference paths
- Update cargo check examples for workspace members
- Note tools registered from yantrik-companion when config is required