### PR TITLE
address #21 (JARVIS, acting on its own review)

### DIFF
--- a/crates/yantrik-design-tokens/slint/theme.slint
+++ b/crates/yantrik-design-tokens/slint/theme.slint
@@ -6,6 +6,7 @@
 
 export global ThemeMode {
     in-out property <bool> dark: true;
+    in-out property <bool> high-contrast: false;
 }
 
 // Accent color presets — index selects which accent palette is active.
@@ -85,16 +86,20 @@ export global Theme {
     // ─── Surface hierarchy (4-tier depth) ─────────────────────────
     // base → default → raised → floating
     // Each tier +6-8% luminance for clear depth without blur.
-    out property <color> bg-deep:     ThemeOverrides.enabled ? ThemeOverrides.bg-deep-override
+    out property <color> bg-deep:     ThemeMode.high-contrast ? #000000
+        : ThemeOverrides.enabled ? ThemeOverrides.bg-deep-override
         : (ThemeMode.dark ? #0c0c14 : #f4f4f6);
-    out property <color> bg-surface:  ThemeOverrides.enabled ? ThemeOverrides.bg-surface-override
+    out property <color> bg-surface:  ThemeMode.high-contrast ? #000000
+        : ThemeOverrides.enabled ? ThemeOverrides.bg-surface-override
         : (ThemeMode.dark ? #161622 : #eaeaee);
-    out property <color> bg-card:     ThemeOverrides.enabled ? ThemeOverrides.bg-card-override
+    out property <color> bg-card:     ThemeMode.high-contrast ? #0a0a0a
+        : ThemeOverrides.enabled ? ThemeOverrides.bg-card-override
         : (ThemeMode.dark ? #1e1e2e : #ffffff);
-    out property <color> bg-elevated: ThemeOverrides.enabled ? ThemeOverrides.bg-elevated-override
+    out property <color> bg-elevated: ThemeMode.high-contrast ? #111111
+        : ThemeOverrides.enabled ? ThemeOverrides.bg-elevated-override
         : (ThemeMode.dark ? #262638 : #ffffff);
-    out property <color> bg-input:    ThemeMode.dark ? #12121e : #f0f0f4;
-    out property <color> bg-selected: ThemeMode.dark ? #1a1a2a : #e4e4ee;
+    out property <color> bg-input:    ThemeMode.high-contrast ? #111111 : (ThemeMode.dark ? #12121e : #f0f0f4);
+    out property <color> bg-selected: ThemeMode.high-contrast ? #222222 : (ThemeMode.dark ? #1a1a2a : #e4e4ee);
 
     // ─── Amber palette ────────────────────────────────────────────
     out property <color> amber:             ThemeOverrides.enabled ? ThemeOverrides.amber-override
@@ -155,22 +160,25 @@ export global Theme {
 
     // ─── Text hierarchy ───────────────────────────────────────────
     // Primary (92% white), Secondary (60%), Tertiary/dim (40%)
-    out property <color> text-primary:   ThemeOverrides.enabled ? ThemeOverrides.text-primary-override
+    out property <color> text-primary:   ThemeMode.high-contrast ? #ffffff
+        : ThemeOverrides.enabled ? ThemeOverrides.text-primary-override
         : (ThemeMode.dark ? #e8eaef : #1a1c20);
-    out property <color> text-secondary: ThemeOverrides.enabled ? ThemeOverrides.text-secondary-override
+    out property <color> text-secondary: ThemeMode.high-contrast ? #ffffff
+        : ThemeOverrides.enabled ? ThemeOverrides.text-secondary-override
         : (ThemeMode.dark ? #8890a0 : #5a6474);
-    out property <color> text-dim:       ThemeOverrides.enabled ? ThemeOverrides.text-dim-override
+    out property <color> text-dim:       ThemeMode.high-contrast ? #cccccc
+        : ThemeOverrides.enabled ? ThemeOverrides.text-dim-override
         : (ThemeMode.dark ? #4a5060 : #a0a8b4);
 
     // ─── Borders & overlays ───────────────────────────────────────
     out property <color> overlay-backdrop:  ThemeMode.dark ? #00000060 : #00000030;
     out property <color> overlay-shadow:    ThemeMode.dark ? #00000080 : #00000040;
-    out property <color> border-subtle:     ThemeMode.dark ? #ffffff06 : #00000006;
-    out property <color> border-default:    ThemeMode.dark ? #ffffff0a : #0000000a;
-    out property <color> border-strong:     ThemeMode.dark ? #ffffff14 : #00000014;
-    out property <color> separator:         ThemeMode.dark ? #ffffff08 : #0000000c;
-    out property <color> hover-fill:        ThemeMode.dark ? #ffffff08 : #00000008;
-    out property <color> hover-fill-strong: ThemeMode.dark ? #ffffff10 : #00000010;
+    out property <color> border-subtle:     ThemeMode.high-contrast ? #ffffff50 : (ThemeMode.dark ? #ffffff06 : #00000006);
+    out property <color> border-default:    ThemeMode.high-contrast ? #ffffff80 : (ThemeMode.dark ? #ffffff0a : #0000000a);
+    out property <color> border-strong:     ThemeMode.high-contrast ? #ffffff : (ThemeMode.dark ? #ffffff14 : #00000014);
+    out property <color> separator:         ThemeMode.high-contrast ? #ffffff50 : (ThemeMode.dark ? #ffffff08 : #0000000c);
+    out property <color> hover-fill:        ThemeMode.high-contrast ? #ffffff18 : (ThemeMode.dark ? #ffffff08 : #00000008);
+    out property <color> hover-fill-strong: ThemeMode.high-contrast ? #ffffff28 : (ThemeMode.dark ? #ffffff10 : #00000010);
     out property <color> tint-cyan:         ThemeMode.dark ? #4ecdc418 : #1a8a9a14;
     out property <color> tint-amber:        ThemeMode.dark ? #d4a57414 : #b0784014;
 

--- a/crates/yantrik-ui-slint/ui/app.slint
+++ b/crates/yantrik-ui-slint/ui/app.slint
@@ -269,6 +269,7 @@ export component App inherits Window {
     in property <string> settings-llm-api-url: "";
     in property <string> settings-llm-api-model: "";
     in-out property <bool> settings-dark-mode: true;
+    in-out property <bool> settings-high-contrast: false;
     in-out property <bool> settings-incognito-mode: false;
     in-out property <string> settings-accent-color: "cyan";
 
@@ -340,6 +341,7 @@ export component App inherits Window {
     callback filter-skill-category(string);
 
     callback toggle-dark-mode();
+    callback toggle-high-contrast();
     callback toggle-incognito-mode();
     callback cycle-accent-color();
     callback cycle-tool-permission();
@@ -2067,10 +2069,12 @@ export component App inherits Window {
                 version-text: root.settings-version;
                 notification-count: root.notification-unread-count;
                 dark-mode <=> root.settings-dark-mode;
+                high-contrast <=> root.settings-high-contrast;
                 incognito-mode <=> root.settings-incognito-mode;
                 dnd-mode <=> root.dnd-mode;
                 accent-color <=> root.settings-accent-color;
                 toggle-dark-mode => { root.toggle-dark-mode(); }
+                toggle-high-contrast => { root.toggle-high-contrast(); }
                 toggle-incognito-mode => { root.toggle-incognito-mode(); }
                 toggle-dnd-mode => { root.toggle-dnd-mode(); }
                 cycle-accent-color => { root.cycle-accent-color(); }

--- a/crates/yantrik-ui-slint/ui/settings.slint
+++ b/crates/yantrik-ui-slint/ui/settings.slint
@@ -95,8 +95,10 @@ export component SettingsScreen inherits Rectangle {
 
     // Appearance
     in-out property <bool> dark-mode: true;
+    in-out property <bool> high-contrast: false;
     in-out property <string> accent-color: "cyan";
     callback toggle-dark-mode();
+    callback toggle-high-contrast();
     callback cycle-accent-color();
 
     // Wallpaper
@@ -472,6 +474,55 @@ export component SettingsScreen inherits Rectangle {
                                                     animate color { duration: Theme.dur-fast; }
                                                 }
                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // High Contrast toggle
+                        Rectangle {
+                            background: Theme.bg-card;
+                            border-radius: Theme.r-lg;
+                            border-width: 1px;
+                            border-color: Theme.border-subtle;
+                            height: 52px;
+
+                            HorizontalLayout {
+                                padding-left: Theme.sp-4;
+                                padding-right: Theme.sp-4;
+
+                                Text {
+                                    text: "High Contrast";
+                                    color: Theme.text-secondary;
+                                    font-size: Theme.fs-body;
+                                    horizontal-stretch: 1;
+                                    vertical-alignment: center;
+                                }
+
+                                hc-ta := TouchArea {
+                                    width: 44px;
+                                    height: 36px;
+                                    clicked => { root.toggle-high-contrast(); }
+
+                                    Rectangle {
+                                        width: 44px;
+                                        height: 24px;
+                                        y: (parent.height - 24px) / 2;
+                                        border-radius: Theme.r-lg;
+                                        background: root.high-contrast ? Theme.accent : Theme.border-default;
+                                        border-width: 1px;
+                                        border-color: root.high-contrast ? Theme.accent-dim : Theme.border-subtle;
+                                        animate background { duration: Theme.dur-fast; }
+
+                                        Rectangle {
+                                            width: 18px;
+                                            height: 18px;
+                                            x: root.high-contrast ? parent.width - 21px : 3px;
+                                            y: 3px;
+                                            border-radius: 9px;
+                                            background: Theme.text-primary;
+                                            animate x { duration: Theme.dur-fast; easing: ease-in-out; }
                                         }
                                     }
                                 }

--- a/crates/yantrik-ui/src/app_context.rs
+++ b/crates/yantrik-ui/src/app_context.rs
@@ -87,6 +87,8 @@ impl AppContext {
         let user_settings = crate::wire::settings::load();
         ui.global::<ThemeMode>().set_dark(user_settings.dark_mode);
         ui.set_settings_dark_mode(user_settings.dark_mode);
+        ui.global::<ThemeMode>().set_high_contrast(user_settings.high_contrast);
+        ui.set_settings_high_contrast(user_settings.high_contrast);
         ui.set_settings_tool_permission(user_settings.tool_permission.clone().into());
         ui.set_settings_auto_lock_secs(user_settings.auto_lock_secs);
         ui.set_dnd_mode(user_settings.dnd_mode);

--- a/crates/yantrik-ui/src/wire/settings.rs
+++ b/crates/yantrik-ui/src/wire/settings.rs
@@ -19,6 +19,7 @@ const WALLPAPER_PRESETS: &[&str] = &["aurora", "sunset", "ocean", "nebula"];
 #[serde(default)]
 pub struct UserSettings {
     pub dark_mode: bool,
+    pub high_contrast: bool,
     pub accent_color: String,
     pub tool_permission: String,
     pub auto_lock_secs: i32,
@@ -34,6 +35,7 @@ impl Default for UserSettings {
     fn default() -> Self {
         Self {
             dark_mode: true,
+            high_contrast: false,
             accent_color: "cyan".into(),
             tool_permission: "sensitive".into(),
             auto_lock_secs: 300,
@@ -139,6 +141,21 @@ pub fn wire(ui: &App, ctx: &AppContext) {
             st.dark_mode = new_val;
         }
         persist(&s);
+    });
+
+    // High contrast toggle
+    let ui_weak = ui.as_weak();
+    let s = settings.clone();
+    ui.on_toggle_high_contrast(move || {
+        let Some(ui) = ui_weak.upgrade() else { return };
+        let new_val = !ui.get_settings_high_contrast();
+        ui.set_settings_high_contrast(new_val);
+        ui.global::<ThemeMode>().set_high_contrast(new_val);
+        if let Ok(mut st) = s.lock() {
+            st.high_contrast = new_val;
+        }
+        persist(&s);
+        tracing::info!(high_contrast = new_val, "High contrast toggled");
     });
 
     // Cycle accent color: cyan → amber → purple → green → pink → cyan


### PR DESCRIPTION
Draft PR opened by JARVIS, acting on its own self-review (not just drafting). Proposed approach:

**Approach:**

1. **Add tokens** in `crates/yantrik-design-tokens/`: create `themes/high-contrast.json` (or extend the existing token schema) with semantic variables — `--color-bg`, `--color-surface`, `--color-text`, `--color-text-muted`, `--color-border`, `--color-accent`, `--color-focus`. Lock to pure black `#000` / white `#FFF` pairs to guarantee ≥7:1 contrast for body text.

2. **Wire runtime**: in the design-tokens crate, expose a `Theme` enum (`Default`, `HighContrast`) and a `current_them

— autonomous; Pranab reviews/merges.